### PR TITLE
Load-aware control test

### DIFF
--- a/load-aware-control/.gitignore
+++ b/load-aware-control/.gitignore
@@ -1,0 +1,1 @@
+artifacts_*/

--- a/load-aware-control/control-test.sh
+++ b/load-aware-control/control-test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -x;
+
+for scheduler in "trimaran" "default"
+do
+    oc get pods -n load-aware -owide
+    time oc apply -f "${scheduler}_test/pod-t1.yaml" -n load-aware
+    time oc apply -f "${scheduler}_test/pod-t2.yaml" -n load-aware
+    time oc apply -f "${scheduler}_test/pod-t3.yaml" -n load-aware
+
+    echo "Let history build up for 5 minutes..."
+    sleep 300
+
+    time oc apply -f "${scheduler}_test/pod-t4.yaml" -n load-aware
+
+    echo "Waiting for pod-t4 to finish..."
+    sleep 180
+
+    artifacts="${scheduler}_artifacts_$(date +%m%d%Y_%H-%M-%S)"
+    mkdir $artifacts
+
+    oc logs -n trimaran -l "app=trimaran-scheduler" > "${artifacts}/trimaran.log"
+    oc get events -n trimaran > "${artifacts}/trimaran_events.log"
+    oc get events -n load-aware > "${artifacts}/load_aware_events.log"
+    oc get pods -n load-aware -ojson > "${artifacts}/pods.json"
+    oc get pods -n load-aware -owide > "${artifacts}/pods.status"
+    oc get nodes -n load-aware -ojson > "${artifacts}/nodes.json"
+    oc get nodes -n load-aware -owide > "${artifacts}/nodes.status"
+    oc delete pods --all -n load-aware
+    sleep 60
+done

--- a/load-aware-control/default_test/pod-t1.yaml
+++ b/load-aware-control/default_test/pod-t1.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: control-1
+  name: control-1-default
   labels:
     workload: make
   annotations:

--- a/load-aware-control/default_test/pod-t1.yaml
+++ b/load-aware-control/default_test/pod-t1.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: control-1
+  labels:
+    workload: make
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+spec:
+  containers:
+  - name: make-container
+    image: load-aware/coreutils:deps
+    imagePullPolicy: IfNotPresent
+    command: ["/bin/sh"]
+    args: ["-c", "for i in {1..999}; do echo echo 'making' && make clean && make -j 4; done"]
+    resources:
+      requests:
+        cpu: "100m"
+  restartPolicy: Never

--- a/load-aware-control/default_test/pod-t2.yaml
+++ b/load-aware-control/default_test/pod-t2.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: control-2
+  name: control-2-default
   labels:
     workload: make
   annotations:

--- a/load-aware-control/default_test/pod-t2.yaml
+++ b/load-aware-control/default_test/pod-t2.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: control-2
+  labels:
+    workload: make
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+spec:
+  containers:
+  - name: make-container
+    image: load-aware/coreutils:deps
+    imagePullPolicy: IfNotPresent
+    command: ["/bin/sh"]
+    args: ["-c", "for i in {1..999}; do echo echo 'making' && make clean && make -j 4; done"]
+    resources:
+      requests:
+        cpu: "100m"
+  restartPolicy: Never

--- a/load-aware-control/default_test/pod-t3.yaml
+++ b/load-aware-control/default_test/pod-t3.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: control-3
+  name: control-3-default
   labels:
     workload: sleep
   annotations:

--- a/load-aware-control/default_test/pod-t3.yaml
+++ b/load-aware-control/default_test/pod-t3.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: control-3
+  labels:
+    workload: sleep
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+spec:
+  containers:
+  - name: sleep-container
+    image: registry.access.redhat.com/ubi8/ubi
+    imagePullPolicy: IfNotPresent
+    command: ["sleep", "9999999"]
+    resources:
+      requests:
+        cpu: "500m"
+  restartPolicy: Never

--- a/load-aware-control/default_test/pod-t4.yaml
+++ b/load-aware-control/default_test/pod-t4.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: control-4
+  name: control-4-default
   labels:
     workload: make
   annotations:

--- a/load-aware-control/default_test/pod-t4.yaml
+++ b/load-aware-control/default_test/pod-t4.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: control-4
+  labels:
+    workload: make
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+spec:
+  containers:
+  - name: make-container
+    image: load-aware/coreutils:deps
+    imagePullPolicy: IfNotPresent
+    command: ["/bin/sh"]
+    args: ["-c", "for i in {1..2}; do echo echo 'making' && make clean && make -j 4; done"]
+    resources:
+      requests:
+        cpu: "100m"
+  restartPolicy: Never

--- a/load-aware-control/trimaran_test/pod-t1.yaml
+++ b/load-aware-control/trimaran_test/pod-t1.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: control-1
+  labels:
+    workload: make
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+spec:
+  schedulerName: "trimaran-scheduler"
+  containers:
+  - name: make-container
+    image: load-aware/coreutils:deps
+    imagePullPolicy: IfNotPresent
+    command: ["/bin/sh"]
+    args: ["-c", "for i in {1..999}; do echo echo 'making' && make clean && make -j 4; done"]
+    resources:
+      requests:
+        cpu: "100m"
+  restartPolicy: Never

--- a/load-aware-control/trimaran_test/pod-t1.yaml
+++ b/load-aware-control/trimaran_test/pod-t1.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: control-1
+  name: control-1-trimaran
   labels:
     workload: make
   annotations:

--- a/load-aware-control/trimaran_test/pod-t2.yaml
+++ b/load-aware-control/trimaran_test/pod-t2.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: control-2
+  name: control-2-trimaran
   labels:
     workload: make
   annotations:

--- a/load-aware-control/trimaran_test/pod-t2.yaml
+++ b/load-aware-control/trimaran_test/pod-t2.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: control-2
+  labels:
+    workload: make
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+spec:
+  schedulerName: "trimaran-scheduler"
+  containers:
+  - name: make-container
+    image: load-aware/coreutils:deps
+    imagePullPolicy: IfNotPresent
+    command: ["/bin/sh"]
+    args: ["-c", "for i in {1..999}; do echo echo 'making' && make clean && make -j 4; done"]
+    resources:
+      requests:
+        cpu: "100m"
+  restartPolicy: Never

--- a/load-aware-control/trimaran_test/pod-t3.yaml
+++ b/load-aware-control/trimaran_test/pod-t3.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: control-3
+  labels:
+    workload: sleep
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+spec:
+  schedulerName: "trimaran-scheduler"
+  containers:
+  - name: sleep-container
+    image: registry.access.redhat.com/ubi8/ubi
+    imagePullPolicy: IfNotPresent
+    command: ["sleep", "9999999"]
+    resources:
+      requests:
+        cpu: "500m"
+  restartPolicy: Never

--- a/load-aware-control/trimaran_test/pod-t3.yaml
+++ b/load-aware-control/trimaran_test/pod-t3.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: control-3
+  name: control-3-trimaran
   labels:
     workload: sleep
   annotations:

--- a/load-aware-control/trimaran_test/pod-t4.yaml
+++ b/load-aware-control/trimaran_test/pod-t4.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: control-4
+  name: control-4-trimaran
   labels:
     workload: make
   annotations:

--- a/load-aware-control/trimaran_test/pod-t4.yaml
+++ b/load-aware-control/trimaran_test/pod-t4.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: control-4
+  labels:
+    workload: make
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+spec:
+  schedulerName: "trimaran-scheduler"
+  containers:
+  - name: make-container
+    image: load-aware/coreutils:deps
+    imagePullPolicy: IfNotPresent
+    command: ["/bin/sh"]
+    args: ["-c", "for i in {1..2}; do echo echo 'making' && make clean && make -j 4; done"]
+    resources:
+      requests:
+        cpu: "100m"
+  restartPolicy: Never


### PR DESCRIPTION
At scale we observed some unexpected behavior with the Trimaran load-aware schedule. This is a small scale test that uses 3 dedicated nodes to test whether the `TargetLoadPacking` plugin is scheduling according to actual load as expected.

This test requires having Trimaran previously deployed.